### PR TITLE
Provide an SSH key to GitBot

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -30,3 +30,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.SSH_KEY }}


### PR DESCRIPTION
Hoping this fixes
"refusing to allow a GitHub App to create or update workflow `.github/workflows/ci.yml` without `workflows` permission"