### PR TITLE
Simplify `copy_subchunk` for improved compile time on recent Julia

### DIFF
--- a/src/sponge.jl
+++ b/src/sponge.jl
@@ -66,11 +66,8 @@ rate(::Sponge{R,NTuple{K,T}}) where {R,K,ELT<:Unsigned,T<:Union{ELT,Vec{<:Any,EL
 ) where {blocklen}
     ntuple(Val(blocklen)) do i
         @inline
-        if !checkindex(Bool, eachindex(data), i-1-destoffset+srcoffset+firstindex(data))
-            return 0x00
-        else
-            return data[i-1-destoffset+srcoffset+firstindex(data)]
-        end
+        j = i-1-destoffset+srcoffset+firstindex(data)
+        return checkindex(Bool, eachindex(data), j) ? data[j] : 0x00
     end
 end
 


### PR DESCRIPTION
I have no idea why, but by not negating the `checkindex`, the time to precompile on Julia 1.13.0-DEV.922 goes down from 400s to 12s on my system. On 1.12.0-rc1, it goes down from 75s to 11s.  Note that precompiling the package does evaluate a bunch of hashes by interpolating them into docstrings. In particular, running (and hance compiling) the `tuplehash` examples took an excessives amount of time.