### PR TITLE
More tests, fix a typo, mild refactoring

### DIFF
--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -10,6 +10,7 @@ issue about it.
 Keccak.Sponge
 Keccak.AbsorbableData
 Keccak.update
+Keccak.lanetype
 Keccak.rate
 ```
 

--- a/src/keccaksponge.jl
+++ b/src/keccaksponge.jl
@@ -39,7 +39,7 @@ be `0b00000110 == 0x06`, and the corresponding padding function would be instant
 struct KeccakPad
     firstbyte::UInt8
     function KeccakPad(firstbyte=0x01)
-        if !(0x01 <= firstbyte <= 0xf7)
+        if !(0x01 <= firstbyte <= 0x7f)
             throw(ArgumentError("invalid first byte of padding"))
         end
         return new(firstbyte)

--- a/src/keccaksponge.jl
+++ b/src/keccaksponge.jl
@@ -45,9 +45,8 @@ struct KeccakPad
         return new(firstbyte)
     end
 end
-function (pad::KeccakPad)(
-    sponge::Sponge{R,NTuple{K,T}}
-) where {R,K,ELT<:Unsigned,T<:Union{ELT,Vec{<:Any,ELT}}}
+function (pad::KeccakPad)(sponge::Sponge{R, NTuple{K, T}} where {T}) where {R, K}
+    ELT = lanetype(sponge)
     J = sizeof(ELT)
     i, j = divrem(sponge.k, J)
     st = let st=sponge.state

--- a/src/kmac.jl
+++ b/src/kmac.jl
@@ -47,6 +47,8 @@ for d in [128, 256]
                 sponge.k,
             )
         end
+        $(kmac_spongefunc)(K::AbsorbableData, ::Val{len}, S::AbsorbableData = ()) where {len} =
+            $(kmac_spongefunc)(K, len, S)
         $(kmac_spongefunc)(K::AbsorbableData, S::AbsorbableData = ()) =
             $(kmac_spongefunc)(K, 0, S)
 
@@ -65,13 +67,12 @@ for d in [128, 256]
             See `$($(kmacxoffunc))` for an alternative.
         """
         function $(kmacfunc)(
-            K::AbsorbableData,
-            data::AbsorbableData,
-            len::Union{Val{L},Integer},
-            S::AbsorbableData = (),
-        ) where {L}
-            intlen = len isa Val ? L : len
-            sponge = $(kmac_spongefunc)(K, intlen, S)
+                K::AbsorbableData,
+                data::AbsorbableData,
+                len::Union{Val, Integer},
+                S::AbsorbableData = (),
+            )
+            sponge = $(kmac_spongefunc)(K, len, S)
             sponge = absorb(sponge, data)
             sponge = pad(sponge)
             return squeeze(sponge, len)[2]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,7 +1,9 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 SIMD = "fdea26ae-647d-5447-a871-4b548cad5224"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
+Aqua = "0.8"
 OffsetArrays = "1.17.0"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -435,6 +435,14 @@ end
 
         @test squeeze(pad(sp), Val(d÷8))[2] == shafunc(input′...) == Tuple(shafunc(inp) for inp in input)
     end
+
+    # test error path for inputs of different size
+    # note: the implementation may conceivably be changed to allow this, but for now
+    # verify that it throws the correct error instead of producing bogus results
+    @test_throws DimensionMismatch shafunc(rand(UInt8, 23), rand(UInt8, 42))
+    @test_throws DimensionMismatch shafunc(rand(UInt8, 23), rand(UInt8, 42), rand(UInt8, 23))
+    @test_throws DimensionMismatch shafunc(rand(UInt8, 23), rand(UInt8, 23), rand(UInt8, 42))
+    @test_throws DimensionMismatch shafunc(rand(UInt8, 23), rand(UInt8, 42), rand(UInt8, 42))
 end
 
 @testset "SHAKE-$d" for (d, shakefunc, spongefunc, empty_ref, len1600_ref) in [
@@ -549,6 +557,14 @@ end
         end
         @test output == collect(shakefunc(input′..., len)) == [shakefunc(inp, len) for inp in input]
     end
+
+    # test error path for inputs of different size
+    # note: the implementation may conceivably be changed to allow this, but for now
+    # verify that it throws the correct error instead of producing bogus results
+    @test_throws DimensionMismatch shakefunc(rand(UInt8, 23), rand(UInt8, 42))
+    @test_throws DimensionMismatch shakefunc(rand(UInt8, 23), rand(UInt8, 42), rand(UInt8, 23))
+    @test_throws DimensionMismatch shakefunc(String(rand(UInt8, 23)), String(rand(UInt8, 23)), String(rand(UInt8, 42)))
+    @test_throws DimensionMismatch shakefunc(Tuple(rand(UInt8, 23)), Tuple(rand(UInt8, 42)), Tuple(rand(UInt8, 42)))
 end
 
 @testset "cSHAKE" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,12 @@
+import Aqua
 using Keccak
 using OffsetArrays: Origin
 using SIMD: Vec
 using Test: @test, @test_throws, @testset
+
+@testset "Aqua.jl" begin
+    Aqua.test_all(Keccak)
+end
 
 @testset "Sponge" begin
     @testset "identity sponge" for intype in [identity, Tuple, String], maybe_val in [identity, Val]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -681,6 +681,7 @@ end
 
     # sample #1
     expected = hex2bytes("CD83740BBD92CCC8CF032B1481A0F4460E7CA9DD12B08A0C4031178BACD6EC35")
+    @test squeeze(pad(absorb(kmac_128_sponge(0x40:0x5f), 0x00:0x03)), 32)[2] == expected
     @test squeeze(pad(absorb(kmac_128_sponge(0x40:0x5f, 0), 0x00:0x03)), 32)[2] == expected
     @test squeeze(kmac_xof_128(0x40:0x5f, 0x00:0x03), Val(32))[2] == Tuple(expected)
     @test kmac_xof_128(0x40:0x5f, 0x00:0x03, 32, "") == expected
@@ -688,6 +689,7 @@ end
 
     # sample #2
     expected = hex2bytes("31A44527B4ED9F5C6101D11DE6D26F0620AA5C341DEF41299657FE9DF1A3B16C")
+    @test squeeze(pad(absorb(kmac_128_sponge(0x40:0x5f, "My Tagged Application"), 0x00:0x03)), 32)[2] == expected
     @test squeeze(pad(absorb(kmac_128_sponge(0x40:0x5f, 0, "My Tagged Application"), 0x00:0x03)), 32)[2] == expected
     @test squeeze(kmac_xof_128(0x40:0x5f, Tuple(0x00:0x03), "My Tagged Application"), Val(32))[2] == Tuple(expected)
     @test kmac_xof_128(0x40:0x5f, 0x00:0x03, 32, codeunits("My Tagged Application")) == expected
@@ -702,13 +704,14 @@ end
 
     # sample #4
     expected = hex2bytes("1755133F1534752AAD0748F2C706FB5C784512CAB835CD15676B16C0C6647FA96FAA7AF634A0BF8FF6DF39374FA00FAD9A39E322A7C92065A64EB1FB0801EB2B")
-    @test squeeze(pad(absorb(kmac_256_sponge(0x40:0x5f, 0, "My Tagged Application"), 0x00:0x03)), 64)[2] == expected
+    @test squeeze(pad(absorb(kmac_256_sponge(0x40:0x5f, "My Tagged Application"), 0x00:0x03)), 64)[2] == expected
     @test squeeze(kmac_xof_256(0x40:0x5f, String(0x00:0x03), Tuple(codeunits("My Tagged Application"))), Val(64))[2] == Tuple(expected)
     @test kmac_xof_256(0x40:0x5f, 0x00:0x03, 64, codeunits("My Tagged Application")) == expected
     @test kmac_xof_256(String(0x40:0x5f), Tuple(0x00:0x03), Val(64), "My Tagged Application") == Tuple(expected)
 
     # sample #5
     expected = hex2bytes("FF7B171F1E8A2B24683EED37830EE797538BA8DC563F6DA1E667391A75EDC02CA633079F81CE12A25F45615EC89972031D18337331D24CEB8F8CA8E6A19FD98B")
+    @test squeeze(pad(absorb(kmac_256_sponge(0x40:0x5f), 0x00:0xc7)), 64)[2] == expected
     @test squeeze(pad(absorb(kmac_256_sponge(0x40:0x5f, 0, ""), 0x00:0xc7)), 64)[2] == expected
     @test squeeze(kmac_xof_256(0x40:0x5f, String(0x00:0xc7)), Val(64))[2] == Tuple(expected)
     @test kmac_xof_256(0x40:0x5f, 0x00:0xc7, 64, UInt8[]) == expected

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -333,6 +333,12 @@ end
     end
     sponge = Keccak.pad(sponge)
     @test Keccak.squeeze(sponge, length(len1600_ref))[2] == len1600_ref
+
+    # trying to create invalid KeccakPad
+    @test_throws ArgumentError KeccakPad(0x00)
+    @test_throws ArgumentError KeccakPad(0x80)
+    @test_throws ArgumentError KeccakPad(200)
+    @test_throws ArgumentError KeccakPad(-1)
 end
 
 @testset "SHA3-$d" for (d, shafunc, spongefunc, empty_ref, len1600_ref) in [


### PR DESCRIPTION
* Rework method signatures/dispatch to avoid the possibility of unbound type parameters. Add a `lanetype` helper along the way.
* Emply Aqua.jl in the tests.
* Test error paths and fix a typo in the condition in the `KeccakPad` constructor.
* Add tests for `absorb_right_encoded` and `absorb_left_encoded`.